### PR TITLE
Remove forced lang from mailing list link. 

### DIFF
--- a/_layouts/master.html
+++ b/_layouts/master.html
@@ -147,7 +147,7 @@
 										<a href="https://github.com/akkadotnet/akka.net">CODE <span>Github repository</span></a>
 									</li>
 									<li class="mega-menu">
-										<a href="https://groups.google.com/forum/?hl=sv#!forum/akkadotnet-user-list">MAILINGLIST <span>Discuss</span></a>
+										<a href="https://groups.google.com/forum/#!forum/akkadotnet-user-list">MAILINGLIST <span>Discuss</span></a>
 									</li>	
 									<li class="mega-menu">
 										<a href="https://github.com/akkadotnet/akka.net/issues">TRACKER <span>Issues and Features</span></a>


### PR DESCRIPTION
Resolves #3.

This removes the language setting from the mailing list link to make it language-neutral.