### PR TITLE
Community site updates 

### DIFF
--- a/_layouts/master.html
+++ b/_layouts/master.html
@@ -46,12 +46,12 @@
 		<link href="/assets/css/header-default.css" rel="stylesheet" type="text/css" />
 		<link href="/assets/css/footer-default.css" rel="stylesheet" type="text/css" />
 		<link href="/assets/css/color_scheme/red.css" rel="stylesheet" type="text/css" id="color_scheme" />
-		
-		
+
+
 		<!-- Highlighting -->
 		<link href="https://highlightjs.org/static/styles/github.css" rel="stylesheet" type="text/css" />
 		<link href="/content/style.css" rel="stylesheet" type="text/css" />
-	
+
 		<!-- Morenizr -->
 		<script type="text/javascript" src="/assets/plugins/modernizr.min.js"></script>
 
@@ -59,15 +59,15 @@
 			<script src="/assets/plugins/respond.js"></script>
 		<![endif]-->
 	</head>
-	
-	<!-- 
-		Available body classes: 
+
+	<!--
+		Available body classes:
 			smoothscroll			= enable chrome browser smooth scroll
 			grey 					= grey content background
 			boxed 					= boxed style
 			pattern1 ... pattern10 	= background pattern
 
-		Background Image - add to body: 
+		Background Image - add to body:
 			data-background="/assets/images/boxed_background/1.jpg"
 	-->
 	<body>
@@ -83,7 +83,7 @@
 						<div class="pull-right fsize13 margin-top10 hide_mobile">
 
 							<!-- mail , phone -->
-							<a href="mailto:akkadotnet@gmail.com">AkkaDotNet@Gmail.com</a> &bull; 
+							<a href="mailto:akkadotnet@gmail.com">AkkaDotNet@Gmail.com</a> &bull;
 
 							<div class="block text-right"><!-- social -->
 								<a href="https://www.facebook.com/akkadotnet" class="social fa fa-facebook"></a>
@@ -125,9 +125,9 @@
 
 								<!--
 									NOTE
-									
+
 									For a regular link, remove "dropdown" class from LI tag and "dropdown-toggle" class from the href.
-									Direct Link Example: 
+									Direct Link Example:
 
 									<li>
 										<a href="#">HOME</a>
@@ -140,7 +140,7 @@
 											HOME <span>welcome</span>
 										</a>
 									</li>
-									<li class="mega-menu{% if page.layout == 'wiki' %} active{% endif %}">										
+									<li class="mega-menu{% if page.layout == 'wiki' %} active{% endif %}">
 										<a href="/wiki/">DOCUMENTATION <span>Wiki</span></a>
 									</li>
 									<li class="mega-menu">
@@ -148,10 +148,10 @@
 									</li>
 									<li class="mega-menu">
 										<a href="https://groups.google.com/forum/#!forum/akkadotnet-user-list">MAILINGLIST <span>Discuss</span></a>
-									</li>	
+									</li>
 									<li class="mega-menu">
 										<a href="https://github.com/akkadotnet/akka.net/issues">TRACKER <span>Issues and Features</span></a>
-									</li>	
+									</li>
 								</ul>
 
 							</nav>
@@ -211,22 +211,22 @@
 							</ul>
 						</div>
 						<!-- /col #3 -->
-						
+
 						<div class="spaced col-md-3 col-sm-4">
 							<h4>Keep <strong>Updated</strong></h4>
 
 							<h4><small><strong>Subscribe to our Newsletter</strong></small></h4>
 
-							
+
 							<!-- Begin MailChimp Signup Form -->
 							<div id="mc_embed_signup">
 							<form class="input-group" action="//github.us8.list-manage.com/subscribe/post?u=945d2a2edaa89aaabd396bc45&amp;id=5f9a7a993d" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-						
+
 								<input type="email" value="" name="EMAIL" class="form-control placeholder required email" id="mce-EMAIL" placeholder="E-mail Address" >
 								<span class="input-group-btn">
 									<button class="btn btn-primary" type="submit" name="subscribe" id="mc-embedded-subscribe">SUBMIT</button>
 								</span>
-					
+
 								<div id="mce-responses" class="clear">
 									<div class="response" id="mce-error-response" style="display:none"></div>
 									<div class="response" id="mce-success-response" style="display:none"></div>
@@ -235,7 +235,7 @@
 							    <div class="clear"></div>
 							</form>
 							</div>
-							
+
 							<!--End mc_embed_signup-->
 
 						</div>
@@ -248,7 +248,7 @@
 				<div class="copyright">
 					<div class="container text-center fsize12">
 						<!--Epona theme by <a href="http://www.stepofweb.com" target="_blank" title="bootstrap themes &amp; templates" class="copyright">stepofweb</a> &bull; All Right Reserved &copy; Your Company LLC. &nbsp;
-						<a href="page-privacy.html" class="fsize11">Privacy Policy</a> &bull; 
+						<a href="page-privacy.html" class="fsize11">Privacy Policy</a> &bull;
 						<a href="page-terms.html" class="fsize11">Terms of Service</a>-->
 					</div>
 				</div>
@@ -279,5 +279,9 @@
 
 		<script type="text/javascript" src="/assets/js/scripts.js"></script>
 		<script type="text/javascript" src="/content/scripts.js"></script>
+
+		<!-- REACTIVE MANIFESTO BANNER -->
+		<a href="http://www.reactivemanifesto.org/"> <img style="border: 0; position: fixed; left: 0; top:0; z-index: 9000; max-width: 110px;" src="//d379ifj7s9wntv.cloudfront.net/reactivemanifesto/images/ribbons/we-are-reactive-red-left.png"> </a>
+
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,158 +1,129 @@
 ---
 layout: master
 ---
-
-			<div class="parallax parallax-1" style='background-image: url("/content/images/akka.jpg")'>
-				<span class="parallax-overlay"></span>
-
-				<div class="container parallax-content">
-
-					<div class="row">
-						<div class="col-md-5 col-sm-5" >
-						
-			<h1 style="text-shadow: 1px 1px #000;">Try <strong>Akka.NET</strong> now!</h1>
-			<p>Follow our tutorial and build your first Akka.NET application today.</p>
-			<div class="btn-group btn-group-lg">
-			<a href="/wiki/Getting started" class="btn btn-success btn-lg" style="text-shadow: 1px 1px #000;"><i class="fa fa-play"></i> Get Started Now</a>
-			</div> <div class="btn-group btn-group-lg">
-			<a href="/wiki" class="btn btn-warning btn-lg" style="text-shadow: 1px 1px #000;"><i class="fa fa-graduation-cap"></i> Documentation</a>
-			</div>
-
-						</div>
-
-						<div class="col-md-7 col-sm-7 text-right">
-						
-						</div>
-					</div>
-				</div>
-			</div>
-
-			<div class="callout dark arrow-down">
-				<div class="container">
-					<div class="row">
-						<div class="col-md-10">
-							<h2>
-							Build powerful <strong>concurrent</strong> &amp; <strong>distributed</strong> applications.
-							</h2>
-							<p class="">Akka.NET is a toolkit and runtime for building highly concurrent, distributed, and fault tolerant event-driven applications on .NET and Mono..</p>
-						</div>
-						<div class="col-md-2">
-						</div>	
-					</div>
-				</div>
-			</div>
-
-			<!-- WELCOME -->
-			<section>
-				<div class="container">
-					<!-- FEATURED BOXES 3 -->
-					<div class="row featured-box-minimal">
-
-						<div class="col-md-4 col-sm-6 col-xs-12">
-							<h4><i class="fa fa-arrows-alt"></i> Simple Concurrency &amp; Distribution</h4>
-							<p>Asynchronous and Distributed by design. High-level abstractions like Actors and FSM.</p>
-						</div>
-
-						<div class="col-md-4 col-sm-6 col-xs-12">
-							<h4><i class="fa fa-flash"></i> High Performance</h4>
-							<p>50 million msg/sec on a single machine. Small memory footprint; ~2.5 million actors per GB of heap.</p>
-						</div>
-
-						<div class="col-md-4 col-sm-6 col-xs-12">
-							<h4><i class="fa fa-shield"></i> Resilient by Design</h4>
-							<p>Write systems that self-heal. Remote and/or local supervisor hierarchies.</p>
-						</div>
-
-				
-						<div class="col-md-4 col-sm-6 col-xs-12">
-							<h4><i class="fa fa-th-large"></i> Elastic & Decentralized</h4>
-							<p>Adaptive load balancing, routing, partitioning and configuration-driven remoting.</p>
-						</div>
-
-						<div class="col-md-4 col-sm-6 col-xs-12">
-							<h4><i class="fa fa-plus-circle"></i> Extensible</h4>
-							<p>Use Akka.NET Extensions to adapt Akka to fit your needs.</p>
-						</div>
-				
-						<div class="col-md-4 col-sm-6 col-xs-12">
-							<h4><i class="fa fa-exclamation"></i> Open Source </h4>
-							<p>Akka.NET is released under the Apache 2 license</p>
-						</div>
-				
-					</div>
-					<!-- /FEATURED BOXES 3 -->
-
-				</div>
-			</section>
-			<!-- /WELCOME -->
-			
-			<!-- PREMIUM -->
-			<section class="alternate">
-				<div class="container">
-				
-					<div class="row">
-						<div class="col-md-6">
-<h2><strong>Actor</strong> Model</h2>
-							<p class="lead">
-The Actor Model provides a higher level of abstraction for writing concurrent and distributed systems. It alleviates the developer from having to deal with explicit locking and thread management, making it easier to write correct concurrent and parallel systems. </p>
-							<p>Actors were defined in the 1973 paper by <a href="http://en.wikipedia.org/wiki/Carl_Hewitt">Carl Hewitt</a> but have been popularized by the Erlang language, and used for example at Ericsson with great success to build highly concurrent and reliable telecom systems.</p>
-							<p><a href="/wiki/Actors">Read more</a></p>
-						</div>
-						
-						<div class="col-md-6 text-center">
-
-							<img class="img-responsive img-rounded appear-animation" data-animation="fadeIn" style="border:2px solid white;width:100%;border-radius:10px" src="/content/images/actor.png" alt="" />
-						</div>
-					</div>
-					<div class="row">
-						<div class="col-md-6">
-<h2><strong>Distributed</strong> by Default</h2>
-							<p class="lead">
-Everything in Akka.NET is designed to work in a distributed setting: all interactions of actors use purely message passing and everything is asynchronous.
-</p>
-							<p>This effort has been undertaken to ensure that all functions are available equally when running within a single process or on a cluster of hundreds of machines. The key for enabling this is to go from remote to local by way of optimization instead of trying to go from local to remote by way of generalization. See this classic paper for a detailed discussion on why the second approach is bound to fail.
-							</p>
-							<p><a href="/wiki/Remoting">Read more</a></p>
-						</div>
-						
-						<div class="col-md-6 text-center">
-							<img class="img-responsive img-rounded appear-animation" data-animation="fadeIn" style="border:2px solid white;width:100%;border-radius:10px" src="/content/images/network.png" alt="" />
-						</div>
-					</div>
-					<div class="row">
-						<div class="col-md-6">
-<h2><strong>Supervision</strong> &amp; monitoring</h2>
-							<p class="lead">
-Actors form a tree with actors being parents to the actors they've created.</p>
-							<p>
-As a parent, the actor is responsible for handling its children’s failures (so-called supervision), forming a chain of responsibility, all the way to the top. When an actor crashes, its parent can either restart or stop it, or escalate the failure up the hierarchy of actors.
-This enables a clean set of semantics for managing failures in a concurrent, distributed system and allows for writing highly fault-tolerant systems that self-heal.</p>
-<p><a href="/wiki/Supervision">Read more</a></p>
-						</div>
-						
-						<div class="col-md-6 text-center">
-							<img class="img-responsive img-rounded appear-animation" data-animation="fadeIn" style="border:2px solid white;width:100%;border-radius:10px" src="/content/images/supervision.png" alt="" />
-						</div>
-					</div>
-				</div>
-			</section>
-			<!-- /PREMIUM -->
-
-			<section class="callout styleBackgroundColor"><!-- add "styleBackgroundColor" class for colored background and white text OR "dark" for a dark callout -->
-				<div class="container">
-
-					<div class="row">
-
-						<div class="col-md-9"><!-- title + shortdesc -->
-							<h3>Who are we?</h3>
-							<p>Meet the people behind Akka.NET!</p>
-						</div>
-
-						<div class="col-md-3"><!-- button -->
-							<a href="/pages/team" class="btn btn-primary btn-lg">Read more</a>
-						</div>
-
-					</div>
-
-				</div>
-			</section>
+<div class="parallax parallax-1" style='background-image: url("/content/images/akka.jpg")'>
+    <span class="parallax-overlay"></span>
+    <div class="container parallax-content">
+        <div class="row">
+            <div class="col-md-5 col-sm-5">
+                <h1 style="text-shadow: 1px 1px #000;">Try <strong>Akka.NET</strong> now!</h1>
+                <p>Follow our tutorial and build your first Akka.NET application today.</p>
+                <div class="btn-group btn-group-lg">
+                    <a href="/wiki/Getting started" class="btn btn-success btn-lg" style="text-shadow: 1px 1px #000;"><i class="fa fa-play"></i> Get Started Now</a>
+                </div>
+                <div class="btn-group btn-group-lg">
+                    <a href="/wiki" class="btn btn-warning btn-lg" style="text-shadow: 1px 1px #000;"><i class="fa fa-graduation-cap"></i> Documentation</a>
+                </div>
+            </div>
+            <div class="col-md-7 col-sm-7 text-right">
+            </div>
+        </div>
+    </div>
+</div>
+<div class="callout dark arrow-down">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-10">
+                <h2>Build powerful concurrent &amp; distributed applications <strong>more easily</strong>.</h2>
+                <p>Akka.NET is a toolkit and runtime for building highly concurrent, distributed, and fault tolerant event-driven applications on .NET and Mono.</p>
+            </div>
+            <div class="col-md-2">
+            </div>
+        </div>
+    </div>
+</div>
+<!-- WELCOME -->
+<section>
+    <div class="container">
+        <!-- FEATURED BOXES 3 -->
+        <div class="row featured-box-minimal">
+            <div class="col-md-4 col-sm-6 col-xs-12">
+                <h4><i class="fa fa-arrows-alt"></i> Simple Concurrency &amp; Distribution</h4>
+                <p>Asynchronous and Distributed by design. High-level abstractions like Actors and FSM.</p>
+            </div>
+            <div class="col-md-4 col-sm-6 col-xs-12">
+                <h4><i class="fa fa-flash"></i> High Performance</h4>
+                <p>50 million msg/sec on a single machine. Small memory footprint; ~2.5 million actors per GB of heap.</p>
+            </div>
+            <div class="col-md-4 col-sm-6 col-xs-12">
+                <h4><i class="fa fa-shield"></i> Resilient by Design</h4>
+                <p>Write systems that self-heal. Remote and/or local supervisor hierarchies.</p>
+            </div>
+            <div class="col-md-4 col-sm-6 col-xs-12">
+                <h4><i class="fa fa-th-large"></i> Elastic & Decentralized</h4>
+                <p>Adaptive load balancing, routing, partitioning and configuration-driven remoting.</p>
+            </div>
+            <div class="col-md-4 col-sm-6 col-xs-12">
+                <h4><i class="fa fa-plus-circle"></i> Extensible</h4>
+                <p>Use Akka.NET Extensions to adapt Akka to fit your needs.</p>
+            </div>
+            <div class="col-md-4 col-sm-6 col-xs-12">
+                <h4><i class="fa fa-exclamation"></i> Open Source </h4>
+                <p>Akka.NET is released under the Apache 2 license</p>
+            </div>
+        </div>
+        <!-- /FEATURED BOXES 3 -->
+    </div>
+</section>
+<!-- /WELCOME -->
+<!-- PREMIUM -->
+<section class="alternate">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-6">
+                <h2><strong>Actor</strong> Model</h2>
+                <p class="lead">
+                    The Actor Model provides a higher level of abstraction for writing concurrent and distributed systems. It alleviates the developer from having to deal with explicit locking and thread management, making it easier to write correct concurrent and parallel systems. </p>
+                <p>Actors were defined in the 1973 paper by <a href="http://en.wikipedia.org/wiki/Carl_Hewitt">Carl Hewitt</a> but have been popularized by the Erlang language, and used for example at Ericsson with great success to build highly concurrent and reliable telecom systems.</p>
+                <p><a href="/wiki/Actors">Read more</a></p>
+            </div>
+            <div class="col-md-6 text-center">
+                <img class="img-responsive img-rounded appear-animation" data-animation="fadeIn" style="border:2px solid white;width:100%;border-radius:10px" src="/content/images/actor.png" alt="" />
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-6">
+                <h2><strong>Distributed</strong> by Default</h2>
+                <p class="lead">
+                    Everything in Akka.NET is designed to work in a distributed setting: all interactions of actors use purely message passing and everything is asynchronous.
+                </p>
+                <p>This effort has been undertaken to ensure that all functions are available equally when running within a single process or on a cluster of hundreds of machines. The key for enabling this is to go from remote to local by way of optimization instead of trying to go from local to remote by way of generalization. See this classic paper for a detailed discussion on why the second approach is bound to fail.
+                </p>
+                <p><a href="/wiki/Remoting">Read more</a></p>
+            </div>
+            <div class="col-md-6 text-center">
+                <img class="img-responsive img-rounded appear-animation" data-animation="fadeIn" style="border:2px solid white;width:100%;border-radius:10px" src="/content/images/network.png" alt="" />
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-6">
+                <h2><strong>Supervision</strong> &amp; monitoring</h2>
+                <p class="lead">
+                    Actors form a tree with actors being parents to the actors they've created.</p>
+                <p>
+                    As a parent, the actor is responsible for handling its children’s failures (so-called supervision), forming a chain of responsibility, all the way to the top. When an actor crashes, its parent can either restart or stop it, or escalate the failure up the hierarchy of actors. This enables a clean set of semantics for managing failures in a concurrent, distributed system and allows for writing highly fault-tolerant systems that self-heal.</p>
+                <p><a href="/wiki/Supervision">Read more</a></p>
+            </div>
+            <div class="col-md-6 text-center">
+                <img class="img-responsive img-rounded appear-animation" data-animation="fadeIn" style="border:2px solid white;width:100%;border-radius:10px" src="/content/images/supervision.png" alt="" />
+            </div>
+        </div>
+    </div>
+</section>
+<!-- /PREMIUM -->
+<section class="callout styleBackgroundColor">
+    <!-- add "styleBackgroundColor" class for colored background and white text OR "dark" for a dark callout -->
+    <div class="container">
+        <div class="row">
+            <div class="col-md-9">
+                <!-- title + shortdesc -->
+                <h3>Who are we?</h3>
+                <p>Meet the people behind Akka.NET!</p>
+            </div>
+            <div class="col-md-3">
+                <!-- button -->
+                <a href="/pages/team" class="btn btn-primary btn-lg">Read more</a>
+            </div>
+        </div>
+    </div>
+</section>

--- a/index.html
+++ b/index.html
@@ -25,10 +25,10 @@ layout: master
         <div class="row">
             <div class="col-md-10">
                 <h2>Build powerful concurrent &amp; distributed applications <strong>more easily</strong>.</h2>
-                <p>Akka.NET is a toolkit and runtime for building highly concurrent, distributed, and fault tolerant event-driven applications on .NET and Mono.</p>
+                <p>Akka.NET is a toolkit and runtime for building highly concurrent, distributed, and fault tolerant event-driven applications on <strong>.NET</strong> &amp; <strong>Mono</strong>.</p>
+                <p style="margin-top: 20px;">This community-driven port brings <strong>C#</strong> &amp; <strong>F#</strong> developers the capabilities of the original Akka framework in Java/Scala. Learn about Akka for the JVM <a href="http://akka.io" target="_blank">here</a>.</p>
             </div>
-            <div class="col-md-2">
-            </div>
+            <div class="col-md-2"></div>
         </div>
     </div>
 </div>

--- a/pages/team.html
+++ b/pages/team.html
@@ -22,7 +22,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-12">
-                <i class="fa fa-warning"></i> This is a community driven port and is not affiliated with <a href="http://typesafe.com">Typesafe</a> who makes the original Java/Scala version of <a href="http://akka.io">Akka</a>.
+                This community-driven port brings <strong>C#</strong> &amp; <strong>F#</strong> developers the capabilities of the original Akka framework in Java/Scala. Learn about Akka for the JVM <a href="http://akka.io" target="_blank">here</a>.
                 <br/>
             </div>
         </div>

--- a/pages/team.html
+++ b/pages/team.html
@@ -7,7 +7,7 @@
             <ul class="breadcrumb">
                 <!-- breadcrumb -->
                 <li><a href="#">Pages</a></li>
-                <li class="active">About Our Team</li>
+                <li class="active">Team</li>
             </ul>
             <!-- /breadcrumb -->
             <h2><!-- Page Title -->
@@ -18,15 +18,6 @@
     </div>
 </section>
 <!-- /PAGE TOP -->
-<section class="callout dark">
-    <div class="container">
-        <div class="row">
-            <div class="col-md-12">
-                This community-driven port brings <strong>C#</strong> &amp; <strong>F#</strong> developers the capabilities of the original Akka framework in Java/Scala. Learn about Akka for the JVM <a href="http://akka.io" target="_blank">here</a>.
-                <br/>
-            </div>
-        </div>
-</section>
 <section>
     <div class="container">
         <p class="lead">Meet the core Akka.NET team below.</p>
@@ -205,7 +196,6 @@
     </div>
     </div>
     </div>
-    >>>>>>> HTML formatting/readability (no content changes)
 </section>
 <script>
 var app = angular.module('app', []);

--- a/pages/team.html
+++ b/pages/team.html
@@ -1,266 +1,246 @@
----
-layout: master
----
+--- layout: master ---
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
 <!-- PAGE TOP -->
 <section class="page-title">
-	<div class="container">
-
-		<header>
-
-			<ul class="breadcrumb"><!-- breadcrumb -->
-				<li><a href="#">Pages</a></li>
-				<li class="active">About Our Team</li>
-			</ul><!-- /breadcrumb -->
-
-			<h2><!-- Page Title -->
-				<strong>About</strong> Our Team
-			</h2><!-- /Page Title -->
-
-		</header>
-
-	</div>
+    <div class="container">
+        <header>
+            <ul class="breadcrumb">
+                <!-- breadcrumb -->
+                <li><a href="#">Pages</a></li>
+                <li class="active">About Our Team</li>
+            </ul>
+            <!-- /breadcrumb -->
+            <h2><!-- Page Title -->
+                <strong>About</strong> Our Team
+            </h2>
+            <!-- /Page Title -->
+        </header>
+    </div>
 </section>
 <!-- /PAGE TOP -->
-
 <section class="callout dark">
-<div class="container">
-
-	<div class="row">
-		<div class="col-md-12">
-		<i class="fa fa-warning"></i>
-		This is a community driven port and is not affiliated with <a href="http://typesafe.com">Typesafe</a> who makes the original Java/Scala version of <a href="http://akka.io">Akka</a>.<br/>
-		</div>
-	</div>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12">
+                <i class="fa fa-warning"></i> This is a community driven port and is not affiliated with <a href="http://typesafe.com">Typesafe</a> who makes the original Java/Scala version of <a href="http://akka.io">Akka</a>.
+                <br/>
+            </div>
+        </div>
 </section>
-
 <section>
-	<div class="container">
-
-		<p class="lead">Meet the core Akka.NET team below.</p>
-
-
-		<div class="row">
-
-			<div class="col-sm-4 col-md-3 fadeInUpBig"><!-- member -->
-				<div class="box-content thumbnail text-center">
-					<span class="item-image">
-						<img class="img-responsive" src="https://avatars3.githubusercontent.com/u/647031?v=2&amp;s=460" alt="">
-					</span>
-					<div class="caption text-left">
-
-						<div class="clearfix margin-bottom10">
-							<div class="pull-left">
-								<h4 class="nomargin">Roger Alsing
-									<small class="block">Founder / Core team</small>
-								</h4>
-							</div>
-							<div class="pull-right">
-								<a href="http://twitter.com/rogeralsing" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
-								<a href="https://github.com/rogeralsing" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
-							</div>
-
-						</div>
-
-						<p class="noborder nomargin nopadding">Roger is the original creator of the Akka.NET project. C# developer and mentor living in Sweden. Open source enthusiast. Started programming at the age of 10 on the mighty Commodore64. <a href="http://twitter.com/rogeralsing">Follow Roger on Twitter</a> or at his <a href="http://rogeralsing.com/">personal blog</a>. Works at <a href="http://Nethouse.se">Nethouse.se</a></p>
-					</div>
-				</div>
-			</div>
-
-			<div class="col-sm-4 col-md-3 fadeInUpBig"><!-- member -->
-				<div class="box-content thumbnail text-center">
-					<span class="item-image">
-						<img class="img-responsive" src="https://avatars0.githubusercontent.com/u/326939?v=2&amp;s=460" alt="">
-					</span>
-					<div class="caption text-left">
-
-						<div class="clearfix margin-bottom10">
-							<div class="pull-left">
-								<h4 class="nomargin">Aaron Stannard
-									<small class="block">Founder / Core team</small>
-								</h4>
-							</div>
-							<div class="pull-right">
-								<a href="http://twitter.com/aaronontheweb" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
-								<a href="https://github.com/aaronontheweb" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
-							</div>
-
-						</div>
-
-						<p class="noborder nomargin nopadding">Aaron is Founder and CTO at <a href="http://petabridge.com">Petabridge, a .NET data platform company</a>. Aaron's one of the original contributors to Akka.NET, authoring the Akka.Remote module and Helios, the underlying socket server. Prior to working at Petabridge Aaron founded MarkedUp Analytics, a Cassandra and Akka.NET-powered real-time app analytics and marketing automation company for app developers.</p>
-					</div>
-				</div>
-			</div>
-
-			<div class="col-sm-4 col-md-3 fadeInUpBig"><!-- member -->
-				<div class="box-content thumbnail text-center">
-					<span class="item-image">
-						<img class="img-responsive" src="https://avatars0.githubusercontent.com/u/800302?v=2&amp;s=460" alt="">
-					</span>
-					<div class="caption text-left">
-
-						<div class="clearfix margin-bottom10">
-							<div class="pull-left">
-								<h4 class="nomargin">Håkan Canberger
-									<small class="block">Core team</small>
-								</h4>
-							</div>
-							<div class="pull-right">
-								<a href="http://twitter.com/hcanber" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
-								<a href="https://github.com/hcanber" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
-							</div>
-
-						</div>
-
-						<p class="noborder nomargin nopadding">Håkan developed the Akka.NET TestKit and internals, and by day is a developer & architect at <a href="http://www.ving.se/">Thomas Cook</a>. Follow Håkan <a href="https://twitter.com/hcanber">on Twitter</a> or at <a href="http://blog.canberger.se/">his personal blog</a>.</p>
-					</div>
-				</div>
-			</div>
-
-			<div class="col-sm-4 col-md-3 fadeInUpBig"><!-- member -->
-				<div class="box-content thumbnail text-center">
-					<span class="item-image">
-						<img class="img-responsive" src="https://avatars0.githubusercontent.com/u/679705?v=2&amp;s=460" alt="">
-					</span>
-					<div class="caption text-left">
-
-						<div class="clearfix margin-bottom10">
-							<div class="pull-left">
-								<h4 class="nomargin">Bartosz Sypytkowski
-									<small class="block">Core team</small>
-								</h4>
-							</div>
-							<div class="pull-right">
-								<a href="http://twitter.com/Horusiath" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
-								<a href="https://github.com/Horusiath" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
-							</div>
-
-						</div>
-
-						<p class="noborder nomargin nopadding">Bartosz wrote the Akka.NET F# API, and works at <a href="http://rd.samsung.pl/?lang=en">Samsung R&D, Poland</a>. Follow <a href="https://twitter.com/horusiath">Bartosz on Twitter</a> or at <a href="http://bartoszsypytkowski.com/">his personal blog</a>.</p>
-					</div>
-				</div>
-			</div>
-
-			<div class="col-sm-4 col-md-3 fadeInUpBig"><!-- member -->
-				<div class="box-content thumbnail text-center">
-					<span class="item-image">
-						<img class="img-responsive" src="https://avatars2.githubusercontent.com/u/1242903?v=2&amp;s=460" alt="">
-					</span>
-					<div class="caption text-left">
-
-						<div class="clearfix margin-bottom10">
-							<div class="pull-left">
-								<h4 class="nomargin">David Smith
-									<small class="block">Core team</small>
-								</h4>
-							</div>
-							<div class="pull-right">
-								<a href="http://twitter.com/smalldave" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
-								<a href="https://github.com/smalldave" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
-							</div>
-
-						</div>
-
-						<p class="noborder nomargin nopadding">David contributed Akka.Cluster and MultiNodeTestkit, and is a developer at <a href="https://www.travelrepublic.co.uk/">Travel Republic</a> in the UK. Follow David on <a href="https://github.com/smalldave">GitHub</a>.</p>
-					</div>
-				</div>
-			</div>
-
-			<div class="col-sm-4 col-md-3 fadeInUpBig"><!-- member -->
-				<div class="box-content thumbnail text-center">
-					<span class="item-image">
-						<img class="img-responsive" src="https://avatars0.githubusercontent.com/u/146717?v=2&amp;s=460" alt="">
-					</span>
-					<div class="caption text-left">
-
-						<div class="clearfix margin-bottom10">
-							<div class="pull-left">
-								<h4 class="nomargin">Jérémie Chassaing
-									<small class="block">Core team</small>
-								</h4>
-							</div>
-							<div class="pull-right">
-								<a href="http://twitter.com/thinkb4coding" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
-								<a href="https://github.com/thinkbeforecoding" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
-							</div>
-
-						</div>
-
-						<p class="noborder nomargin nopadding">Jérémie is an F# developer hailing from Paris, France. Follow him on <a href="https://twitter.com/thinkb4coding">Twitter</a> or at his personal blog, <a href="http://thinkbeforecoding.com/">Think Before Coding</a>.</p>
-					</div>
-				</div>
-			</div>
-		</div>
-
-		<p class="lead">Full list of contributors.</p>
-
-		<div class="row" ng-app="app">
-			<div ng-controller="TeamController as team">
-			<div ng-repeat="person in team.contributors">
-			<div class="col-sm-4 col-md-3 fadeInUpBig" ng-controller="ContributorController as contributor"><!-- member -->
-				<div class="box-content thumbnail text-center" ng-controller="ContributorController as contributor">
-					<span class="item-image">
-						<img class="img-responsive" ng-src="[[person.author.avatar_url]]" alt="">
-					</span>
-					<div class="caption text-left">
-
-						<div class="clearfix margin-bottom10">
-							<div class="pull-left">
-								<h4 class="nomargin">[[contributor.data.name || "-"]]
-									<small class="block">[[person.author.login]]</small>
-								</h4>
-							</div>
-							<div class="pull-right">
-								<a href="[[person.author.html_url]]" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
-							</div>
-
-						</div>
-
-						<p class="noborder nomargin nopadding">Commits: [[person.total]]</p>
-					</div>
-				</div>
-			</div>
-			</div>
-			</div>
-		</div>
-	</div>
+    <div class="container">
+        <p class="lead">Meet the core Akka.NET team below.</p>
+        <div class="row">
+            <div class="col-sm-4 col-md-3 fadeInUpBig">
+                <!-- member -->
+                <div class="box-content thumbnail text-center">
+                    <span class="item-image">
+                        <img class="img-responsive" src="https://avatars3.githubusercontent.com/u/647031?v=2&amp;s=460" alt="">
+                    </span>
+                    <div class="caption text-left">
+                        <div class="clearfix margin-bottom10">
+                            <div class="pull-left">
+                                <h4 class="nomargin">Roger Alsing
+                                    <small class="block">Founder / Core team</small>
+                                </h4>
+                            </div>
+                            <div class="pull-right">
+                                <a href="http://twitter.com/rogeralsing" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
+                                <a href="https://github.com/rogeralsing" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
+                            </div>
+                        </div>
+                        <p class="noborder nomargin nopadding">Roger is the original creator of the Akka.NET project. C# developer and mentor living in Sweden. Open source enthusiast. Started programming at the age of 10 on the mighty Commodore64. <a href="http://twitter.com/rogeralsing">Follow Roger on Twitter</a> or at his <a href="http://rogeralsing.com/">personal blog</a>. Works at <a href="http://Nethouse.se">Nethouse.se</a></p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4 col-md-3 fadeInUpBig">
+                <!-- member -->
+                <div class="box-content thumbnail text-center">
+                    <span class="item-image">
+                        <img class="img-responsive" src="https://avatars0.githubusercontent.com/u/326939?v=2&amp;s=460" alt="">
+                    </span>
+                    <div class="caption text-left">
+                        <div class="clearfix margin-bottom10">
+                            <div class="pull-left">
+                                <h4 class="nomargin">Aaron Stannard
+                                    <small class="block">Founder / Core team</small>
+                                </h4>
+                            </div>
+                            <div class="pull-right">
+                                <a href="http://twitter.com/aaronontheweb" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
+                                <a href="https://github.com/aaronontheweb" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
+                            </div>
+                        </div>
+                        <p class="noborder nomargin nopadding">Aaron is Founder and CTO at <a href="http://petabridge.com">Petabridge, a .NET data platform company</a>. Aaron's one of the original contributors to Akka.NET, authoring the Akka.Remote module and Helios, the underlying socket server. Prior to working at Petabridge Aaron founded MarkedUp Analytics, a Cassandra and Akka.NET-powered real-time app analytics and marketing automation company for app developers.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4 col-md-3 fadeInUpBig">
+                <!-- member -->
+                <div class="box-content thumbnail text-center">
+                    <span class="item-image">
+                        <img class="img-responsive" src="https://avatars0.githubusercontent.com/u/800302?v=2&amp;s=460" alt="">
+                    </span>
+                    <div class="caption text-left">
+                        <div class="clearfix margin-bottom10">
+                            <div class="pull-left">
+                                <h4 class="nomargin">Håkan Canberger
+                                    <small class="block">Core team</small>
+                                </h4>
+                            </div>
+                            <div class="pull-right">
+                                <a href="http://twitter.com/hcanber" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
+                                <a href="https://github.com/hcanber" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
+                            </div>
+                        </div>
+                        <p class="noborder nomargin nopadding">Håkan developed the Akka.NET TestKit and internals, and by day is a developer & architect at <a href="http://www.ving.se/">Thomas Cook</a>. Follow Håkan <a href="https://twitter.com/hcanber">on Twitter</a> or at <a href="http://blog.canberger.se/">his personal blog</a>.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4 col-md-3 fadeInUpBig">
+                <!-- member -->
+                <div class="box-content thumbnail text-center">
+                    <span class="item-image">
+                        <img class="img-responsive" src="https://avatars0.githubusercontent.com/u/679705?v=2&amp;s=460" alt="">
+                    </span>
+                    <div class="caption text-left">
+                        <div class="clearfix margin-bottom10">
+                            <div class="pull-left">
+                                <h4 class="nomargin">Bartosz Sypytkowski
+                                    <small class="block">Core team</small>
+                                </h4>
+                            </div>
+                            <div class="pull-right">
+                                <a href="http://twitter.com/Horusiath" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
+                                <a href="https://github.com/Horusiath" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
+                            </div>
+                        </div>
+                        <p class="noborder nomargin nopadding">Bartosz wrote the Akka.NET F# API, and works at <a href="http://rd.samsung.pl/?lang=en">Samsung R&D, Poland</a>. Follow <a href="https://twitter.com/horusiath">Bartosz on Twitter</a> or at <a href="http://bartoszsypytkowski.com/">his personal blog</a>.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4 col-md-3 fadeInUpBig">
+                <!-- member -->
+                <div class="box-content thumbnail text-center">
+                    <span class="item-image">
+                        <img class="img-responsive" src="https://avatars2.githubusercontent.com/u/1242903?v=2&amp;s=460" alt="">
+                    </span>
+                    <div class="caption text-left">
+                        <div class="clearfix margin-bottom10">
+                            <div class="pull-left">
+                                <h4 class="nomargin">David Smith
+                                    <small class="block">Core team</small>
+                                </h4>
+                            </div>
+                            <div class="pull-right">
+                                <a href="http://twitter.com/smalldave" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
+                                <a href="https://github.com/smalldave" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
+                            </div>
+                        </div>
+                        <p class="noborder nomargin nopadding">David contributed Akka.Cluster and MultiNodeTestkit, and is a developer at <a href="https://www.travelrepublic.co.uk/">Travel Republic</a> in the UK. Follow David on <a href="https://github.com/smalldave">GitHub</a>.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4 col-md-3 fadeInUpBig">
+                <!-- member -->
+                <div class="box-content thumbnail text-center">
+                    <span class="item-image">
+                        <img class="img-responsive" src="https://avatars0.githubusercontent.com/u/146717?v=2&amp;s=460" alt="">
+                    </span>
+                    <div class="caption text-left">
+                        <div class="clearfix margin-bottom10">
+                            <div class="pull-left">
+                                <h4 class="nomargin">Jérémie Chassaing
+                                    <small class="block">Core team</small>
+                                </h4>
+                            </div>
+                            <div class="pull-right">
+                                <a href="http://twitter.com/thinkb4coding" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
+                                <a href="https://github.com/thinkbeforecoding" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
+                            </div>
+                        </div>
+                        <p class="noborder nomargin nopadding">Jérémie is an F# developer hailing from Paris, France. Follow him on <a href="https://twitter.com/thinkb4coding">Twitter</a> or at his personal blog, <a href="http://thinkbeforecoding.com/">Think Before Coding</a>.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <p class="lead">Full list of contributors.</p>
+        <div class="row" ng-app="app">
+            <div ng-controller="TeamController as team">
+                <div ng-repeat="person in team.contributors">
+                    <div class="col-sm-4 col-md-3 fadeInUpBig" ng-controller="ContributorController as contributor">
+                        <!-- member -->
+                        <div class="box-content thumbnail text-center" ng-controller="ContributorController as contributor">
+                            <span class="item-image">
+                        <img class="img-responsive" ng-src="[[person.author.avatar_url]]" alt="">
+                    </span>
+                            <div class="caption text-left">
+                                <div class="clearfix margin-bottom10">
+                                    <div class="pull-left">
+                                        <h4 class="nomargin">[[contributor.data.name || "-"]]
+                                    <small class="block">[[person.author.login]]</small>
+                                </h4>
+                                    </div>
+                                    <div class="pull-right">
+                                        <a href="[[person.author.html_url]]" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
+                                    </div>
+                                </div>
+                                <p class="noborder nomargin nopadding">Commits: [[person.total]]</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    </div>
+    <div class="pull-right">
+        <a href="http://twitter.com/thinkb4coding" class="btn ico-only btn-twitter btn-xs"><i class="fa fa-twitter"></i></a>
+        <a href="https://github.com/thinkbeforecoding" class="btn ico-only btn-stackoverflow btn-xs"><i class="fa fa-github"></i></a>
+    </div>
+    </div>
+    <p class="noborder nomargin nopadding">Jérémie is an F# developer hailing from Paris, France. Follow him on <a href="https://twitter.com/thinkb4coding">Twitter</a> or at his personal blog, <a href="http://thinkbeforecoding.com/">Think Before Coding</a>.</p>
+    </div>
+    </div>
+    </div>
+    </div>
+    </div>
+    >>>>>>> HTML formatting/readability (no content changes)
 </section>
 <script>
 var app = angular.module('app', []);
 
-app.config(function($interpolateProvider){
+app.config(function($interpolateProvider) {
     $interpolateProvider.startSymbol('[[').endSymbol(']]');
 });
 
 app.controller('TeamController', function($http) {
-	var team = this;
+    var team = this;
 
-	$http.get('https://api.github.com/repos/akkadotnet/akka.net/stats/contributors').
-	success(function(data, status, headers, config) {
-		team.contributors = data;
-		team.contributors.sort(function(a,b)
-					{
-						return b.total-a.total;
-					});
-	}).
-	error(function(data, status, headers, config) {
-		// called asynchronously if an error occurs
-		// or server returns response with an error status.
-	});
+    $http.get('https://api.github.com/repos/akkadotnet/akka.net/stats/contributors').
+    success(function(data, status, headers, config) {
+        team.contributors = data;
+        team.contributors.sort(function(a, b) {
+            return b.total - a.total;
+        });
+    }).
+    error(function(data, status, headers, config) {
+        // called asynchronously if an error occurs
+        // or server returns response with an error status.
+    });
 });
-app.controller('ContributorController', function($scope,$http) {
-	var contributor = this;
+app.controller('ContributorController', function($scope, $http) {
+    var contributor = this;
 
-	$http.get($scope.person.author.url).
-	success(function(data, status, headers, config) {
-		console.log(data);
-		contributor.data = data;
-	}).
-	error(function(data, status, headers, config) {
-		// called asynchronously if an error occurs
-		// or server returns response with an error status.
-	});
+    $http.get($scope.person.author.url).
+    success(function(data, status, headers, config) {
+        console.log(data);
+        contributor.data = data;
+    }).
+    error(function(data, status, headers, config) {
+        // called asynchronously if an error occurs
+        // or server returns response with an error status.
+    });
 
 });
 </script>


### PR DESCRIPTION
Made some small updates / cleanup to community site prep for 1.0 launch. Typesafe will be adding callout on JVM Akka site that directs to Akka .NET site in reciprocation.

- Add "We are reactive" banner sized so it doesn't block nav items as it did before
- Add callout to JVM partner project in homepage project description
- HTML readability / formatting
- Remove community port warning from team page (redundant vs homepage/footer)